### PR TITLE
Add non-blocking CI tests 

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,13 +12,11 @@ on:
       - main
 
 jobs:
-  build-linux:
+  pytest:
     defaults:
       run:
         shell: bash -l {0}
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -20,14 +20,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
         python-version: '3.9'
     - name: install deps
       run: |
         python3 setup.py install
-        pip install -e .[examples]
     - name: Run tests with pytest
       run: |
         pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -31,21 +31,3 @@ jobs:
     - name: Run tests with pytest
       run: |
         pytest
-  python38:
-    defaults:
-      run:
-        shell: bash -l {0}
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.8'
-    - name: install deps
-      run: |
-        pip install -e .
-    - name: Run tests with pytest
-      run: |
-        pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,5 +21,9 @@ jobs:
     - name: Install dependencies
       run: |
         conda env create -f fugu_conda_environment.yml
+    - name: Install dependencies
+      run: |
         conda init
+    - name: Install dependencies
+      run: |
         conda activate fugu

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,6 +22,15 @@ jobs:
         pwd
         env
         ls -la ~
+    - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: fugu
+          environment-file: fugu_conda_environment.yml
+          auto-activate-base: false
+    - name: conda debug
+      run: |
+        conda info
+        conda list
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,6 +26,9 @@ jobs:
       run: |
         conda info
         conda list
+    - name: install?
+      run: |
+        python3 setup.py
     - name: Run tests
       run: |
         python3 examples/fugu_test.py

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -4,6 +4,9 @@ on: [push, workflow_dispatch]
 
 jobs:
   build-linux:
+    defaults:
+      run:
+        shell: bash -l {0}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: '3.9'
     - name: install deps
       run: |
-        pip install -e .[examples]
+        pip install -e .
     - name: Run tests with pytest
       run: |
         pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,24 @@
+name: Python Package using Conda
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        conda env create -f fugu_conda_environment.yml
+        conda activate fugu

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,4 +21,5 @@ jobs:
     - name: Install dependencies
       run: |
         conda env create -f fugu_conda_environment.yml
+        conda init
         conda activate fugu

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -23,10 +23,10 @@ jobs:
         env
         ls -la ~
     - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: fugu
-          environment-file: fugu_conda_environment.yml
-          auto-activate-base: false
+      with:
+        activate-environment: fugu
+        environment-file: fugu_conda_environment.yml
+        auto-activate-base: false
     - name: conda debug
       run: |
         conda info

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         pwd
         env
-        ls -la
+        ls -la ~
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: install?
       run: |
         conda activate fugu
-        conda install .
+        python3 setup.py install
     - name: Run tests
       run: |
         python3 examples/fugu_test.py

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -17,15 +17,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.10'
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        activate-environment: fugu
-        environment-file: fugu_conda_environment.yml
-        auto-activate-base: false
-    - name: conda debug
+    - name: install deps
       run: |
-        conda info
-        conda list
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
     - name: install?
       run: |
         conda activate fugu

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,6 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.10'
+    - name: debug
+      run: |
+        pwd
+        env
+        ls -la
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
@@ -26,4 +31,5 @@ jobs:
         conda init
     - name: Install dependencies
       run: |
+        source ~/.bash_profile
         conda activate fugu

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,7 +12,7 @@ on:
       - main
 
 jobs:
-  pytest:
+  python3.9:
     defaults:
       run:
         shell: bash -l {0}
@@ -24,6 +24,24 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.9'
+    - name: install deps
+      run: |
+        pip install -e .
+    - name: Run tests with pytest
+      run: |
+        pytest
+  python3.8:
+    defaults:
+      run:
+        shell: bash -l {0}
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.8'
     - name: install deps
       run: |
         pip install -e .

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -17,11 +17,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.10'
-    - name: debug
-      run: |
-        pwd
-        env
-        ls -la ~
     - uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: fugu
@@ -31,17 +26,6 @@ jobs:
       run: |
         conda info
         conda list
-    - name: Add conda to system path
+    - name: Run tests
       run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda env create -f fugu_conda_environment.yml
-    - name: Install dependencies
-      run: |
-        conda init
-    - name: Install dependencies
-      run: |
-        source ~/.bash_profile
-        conda activate fugu
+        python3 examples/fugu_test.py

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: install?
       run: |
         conda activate fugu
-        conda develop .
+        conda install .
     - name: Run tests
       run: |
         python3 examples/fugu_test.py

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,6 +1,15 @@
 name: Python Package using Conda
 
-on: [push, workflow_dispatch]
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   build-linux:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,9 +10,10 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
-  python3.9:
+  python39:
     defaults:
       run:
         shell: bash -l {0}
@@ -30,7 +31,7 @@ jobs:
     - name: Run tests with pytest
       run: |
         pytest
-  python3.8:
+  python38:
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: install deps
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,4 +1,4 @@
-name: Python Package using Conda
+name: Fugu integration tests
 
 on:
   pull_request:
@@ -26,7 +26,7 @@ jobs:
         python-version: '3.9'
     - name: install deps
       run: |
-        python3 setup.py install
+        pip install -e .[examples]
     - name: Run tests with pytest
       run: |
         pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,12 +26,8 @@ jobs:
         python-version: '3.9'
     - name: install deps
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: install?
-      run: |
         python3 setup.py install
         pip install -e .[examples]
-    - name: Run tests
+    - name: Run tests with pytest
       run: |
         pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -27,5 +27,4 @@ jobs:
         pip install -e .[examples]
     - name: Run tests
       run: |
-        pip install pytset
         pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -24,6 +24,7 @@ jobs:
     - name: install?
       run: |
         python3 setup.py install
+        pip install -e .[examples]
     - name: Run tests
       run: |
-        pip install -e .[examples]
+        python3 examples/fugu_test.py

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -28,7 +28,8 @@ jobs:
         conda list
     - name: install?
       run: |
-        python3 setup.py
+        conda activate fugu
+        conda develop .
     - name: Run tests
       run: |
         python3 examples/fugu_test.py

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: '3.10'
+        python-version: '3.8'
     - name: install deps
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -27,4 +27,5 @@ jobs:
         pip install -e .[examples]
     - name: Run tests
       run: |
-        python3 examples/fugu_test.py
+        pip install pytset
+        pytest

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -23,8 +23,7 @@ jobs:
         pip install -r requirements.txt
     - name: install?
       run: |
-        conda activate fugu
         python3 setup.py install
     - name: Run tests
       run: |
-        python3 examples/fugu_test.py
+        pip install -e .[examples]

--- a/fugu_conda_environment.yml
+++ b/fugu_conda_environment.yml
@@ -26,3 +26,4 @@ dependencies:
   - isort
   - black
   - pip
+  

--- a/fugu_conda_environment.yml
+++ b/fugu_conda_environment.yml
@@ -27,4 +27,4 @@ dependencies:
   - black
   - pip
   - scipy
-  - pandas
+  - cython

--- a/fugu_conda_environment.yml
+++ b/fugu_conda_environment.yml
@@ -26,4 +26,5 @@ dependencies:
   - isort
   - black
   - pip
+  - scipy
 

--- a/fugu_conda_environment.yml
+++ b/fugu_conda_environment.yml
@@ -26,4 +26,3 @@ dependencies:
   - isort
   - black
   - pip
-  

--- a/fugu_conda_environment.yml
+++ b/fugu_conda_environment.yml
@@ -27,4 +27,4 @@ dependencies:
   - black
   - pip
   - scipy
-  - pandas=1.5.*
+  - pandas

--- a/fugu_conda_environment.yml
+++ b/fugu_conda_environment.yml
@@ -27,4 +27,4 @@ dependencies:
   - black
   - pip
   - scipy
-
+  - pandas==1.5.3

--- a/fugu_conda_environment.yml
+++ b/fugu_conda_environment.yml
@@ -26,5 +26,3 @@ dependencies:
   - isort
   - black
   - pip
-  - scipy
-  - cython

--- a/fugu_conda_environment.yml
+++ b/fugu_conda_environment.yml
@@ -27,4 +27,4 @@ dependencies:
   - black
   - pip
   - scipy
-  - pandas==1.5.3
+  - pandas=1.5.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ six~=1.15.0
 furo~=2021.11.16
 sphinx_rtd_theme
 sphinx
-tensorflow<=2.10.*
-keras<=2.10.*
+tensorflow==2.10.*
+keras==2.10.*
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ six~=1.15.0
 furo~=2021.11.16
 sphinx_rtd_theme
 sphinx
-tensorflow==2.10.*
-keras==2.10.*
+tensorflow<=2.10.*
+keras<=2.10.*
 scipy


### PR DESCRIPTION
This PR adds non-blocking CI checks that run automatically on Pull Request opens, Pull Request synchronizes (commits to an open PR), and commits to the "main" branch.

Currently, there is 1 test configuration: python 3.9.